### PR TITLE
Add sourcemaps to babel build output

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
 	"stage": 0,
-	"optional": ["asyncToGenerator"]
+	"optional": ["asyncToGenerator"],
+	"sourceMaps": "inline"
 }


### PR DESCRIPTION
This adds sourceMaps to the babel-generated build output for easier debugging