### PR TITLE
fix: correct exit code for binary runs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,35 +1,3 @@
 {
-  "parser": "babel-eslint",
-  "env": {
-    "node": true,
-    "browser": true,
-    "es6": true
-  },
-  "rules": {
-    "quotes": [2, "single"]
-  },
-  "ecmaFeatures": {
-    "arrowFunctions": true,
-    "binaryLiterals": true,
-    "blockBindings": true,
-    "classes": true,
-    "defaultParams": true,
-    "destructuring": true,
-    "forOf": true,
-    "generators": true,
-    "modules": true,
-    "objectLiteralComputedProperties": true,
-    "objectLiteralDuplicateProperties": true,
-    "objectLiteralShorthandMethods": true,
-    "objectLiteralShorthandProperties": true,
-    "octalLiterals": true,
-    "regexUFlag": true,
-    "regexYFlag": true,
-    "spread": true,
-    "superInFunctions": true,
-    "templateStrings": true,
-    "unicodeCodePointEscapes": true,
-    "globalReturn": true,
-    "jsx": true
-  }
+	"extends": ["xo/esnext"]
 }

--- a/package.json
+++ b/package.json
@@ -70,8 +70,11 @@
   },
   "devDependencies": {
     "babel": "^5.2.17",
-    "babel-eslint": "^3.0.1",
-    "eslint": "^0.19.0",
+    "babel-eslint": "^3.1.30",
+    "eslint": "^1.10.3",
+    "eslint-config-xo": "^0.8.0",
+    "eslint-plugin-babel": "^3.0.0",
+    "eslint-plugin-react": "^3.11.3",
     "node-inspector": "^0.12.1"
   }
 }

--- a/source/application/tasks/failing-task/index.js
+++ b/source/application/tasks/failing-task/index.js
@@ -1,0 +1,3 @@
+export default async function failingTask() {
+	throw new Error('This task is intended to fail');
+}

--- a/source/application/tasks/test/index.js
+++ b/source/application/tasks/test/index.js
@@ -1,3 +1,3 @@
-export default async function testTask ( application, config ) {
+export default async function testTask(application, config) {
 	console.log(config.message);
 }

--- a/source/binary/boilerplate-console.js
+++ b/source/binary/boilerplate-console.js
@@ -1,21 +1,10 @@
 #!/usr/bin/env node
-/*eslint-disable no-process-env, no-process-exit */
-
-import 'babel-core/polyfill';
-import minimist from 'minimist';
-
 import boilerplate from '../';
+import execute from '../library/utilities/execute';
 
-async function start (options) {
-	const mode = 'console';
-	const settings = {...options, mode};
-	const application = await boilerplate(settings);
-
-	const command = settings._[1]
-	await application.run(command, settings);
+async function main(options) {
+	const application = await boilerplate(options);
+	return await application.run(options.command, options);
 }
 
-const args = minimist(process.argv.slice(1));
-
-start(args)
-	.catch(err => {throw err});
+execute(main, {mode: 'console'});

--- a/source/binary/boilerplate-server.js
+++ b/source/binary/boilerplate-server.js
@@ -1,46 +1,10 @@
 #!/usr/bin/env node
-/*eslint-disable no-process-env, no-process-exit */
-
-import 'babel-core/polyfill';
-import minimist from 'minimist';
-
 import boilerplate from '../';
+import execute from '../library/utilities/execute';
 
-async function start ( options = {} ) {
-	let application;
-	let settings = Object.assign( options, { 'mode': 'server' } );
-
-	try {
-		application = await boilerplate( settings );
-	} catch ( error ) {
-		let log = application ? application.log || console : console;
-		log.error( error );
-		throw new Error( error );
-	}
-
-	try {
-		await application.start();
-		application.log.info('[application] Started without errors.');
-	} catch ( error ) {
-		application.log.error( error );
-		throw new Error( error );
-	}
-
-	async function stop () {
-		try {
-			await application.stop();
-			process.exit( 0 );
-		} catch ( err ) {
-			application.log.error( err );
-			process.exit( 1 );
-		}
-	}
-
-	process.on( 'SIGINT', () => stop( 'SIGINT' ) );
-	process.on( 'SIGHUP', () => stop( 'SIGHUP' ) );
-	process.on( 'SIGQUIT', () => stop( 'SIGQUIT' ) );
-	process.on( 'SIGABRT', () => stop( 'SIGABRT' ) );
-	process.on( 'SIGTERM', () => stop( 'SIGTERM' ) );
+async function main(options = {}) {
+	const application = await boilerplate(options);
+	return await application.start();
 }
 
-start( minimist( process.argv.slice( 1 ) ) );
+execute(main, {mode: 'server'});

--- a/source/library/boot/index.js
+++ b/source/library/boot/index.js
@@ -45,7 +45,8 @@ class BoilerPlateServer extends EventEmitter {
 			return this;
 		}
 
-		return await this.console.run(command, options);
+		await this.console.run(command, options);
+		return this;
 	}
 }
 

--- a/source/library/utilities/execute.js
+++ b/source/library/utilities/execute.js
@@ -1,0 +1,52 @@
+import 'babel-core/polyfill';
+import {basename, extname} from 'path';
+import {merge} from 'lodash';
+import minimist from 'minimist';
+
+// Assemble augmented minimist options
+const args = minimist(process.argv.slice(1));
+const entry = process.argv[1];
+const raw = args._;
+
+const options = {
+	...args,
+	command: raw.slice(1).join(' '),
+	entry: basename(entry, extname(entry))
+};
+
+/**
+ * Handles success of top level Promise resolvers and logs message if any
+ * @param  {object} [instance] Instance to perform success log from
+ * @private
+ */
+function handleSuccess(instance) {
+	if (instance && instance.log) {
+		instance.log.info(`[application] ${options.entry} executed sucessfully.`);
+	}
+}
+
+/**
+ * Handles and escalates top level Promise errors causing the process to crash if uncatched
+ * @param {object} error - Error object to print and escalete
+ * @private
+ */
+function handleError(error) {
+	console.log(`${options.entry} failed.`)
+	console.trace(error);
+
+	setTimeout(() => {
+		throw error;
+	});
+}
+
+/**
+ * Executes a promise based procedure, passes process options to it and handles exceptions
+ * @param {function} procedure - Function to execute, must return Promise
+ * @param {objecet} configuration - Object to deep merge with cli args objects
+ * @return {Promise} result - Promise wrapping the result of the procedure
+ * @private
+ */
+export default (procedure, configuration = {}) =>
+	procedure(merge({}, options, configuration))
+		.then(handleSuccess)
+		.catch(handleError);


### PR DESCRIPTION
This

* introduces eslint-config-xo
* unifies the binary entries
* makes sure correct exit codes are emitted
* fixes a incompatibility in the `instance.run` interface not returning the instance
* shows the way forward concerning inline documentation